### PR TITLE
Add multi-port SMTP configuration and update related services

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ smtp-nodejs/
 - **Modular Architecture**: Clean separation of concerns with dedicated modules
 - **SMTP Protocol Support**: Full SMTP command handling (HELO, MAIL FROM, RCPT TO, DATA, QUIT, RSET)
 - **Email Processing**: MIME parsing with attachment support
+- **Multi-Port SMTP**: Support for ports 25 (forwarding), 587 (STARTTLS), and 465 (SSL)
 - **Email Sending**: DNS MX lookup and external mail server delivery
 - **Dynamic IP Selection**: Send emails from different IP addresses based on API response
 - **Queue Management**: Robust email queue with retry logic and failure tracking
@@ -246,6 +247,12 @@ Test the dynamic IP selection functionality:
 npm run test:ip
 ```
 
+### Multi-Port SMTP Test
+Test the multi-port SMTP functionality:
+```bash
+npm run test:ports
+```
+
 ### Manual Testing
 To test the SMTP server manually, you can use any SMTP client or telnet:
 
@@ -282,6 +289,7 @@ Access the real-time queue dashboard at: http://localhost:3000
 - `GET /api/ip-selection/stats` - Get IP selection cache statistics
 - `POST /api/ip-selection/clear-cache` - Clear IP selection cache
 - `POST /api/ip-selection/test` - Test IP selection for specific email
+- `GET /api/smtp/stats` - Get multi-port SMTP server statistics
 - `GET /health` - Health check
 
 ## 📝 License

--- a/config/config.js
+++ b/config/config.js
@@ -5,6 +5,19 @@ const config = {
     port: process.env.SMTP_PORT || 2525,
     host: process.env.SMTP_HOST || '0.0.0.0',
     apiPort: process.env.API_PORT || 3000,
+    ports: {
+      smtp25: process.env.SMTP_25_PORT || 25,
+      smtp465: process.env.SMTP_465_PORT || 465,
+      smtp587: process.env.SMTP_587_PORT || 587,
+    },
+    forward25: {
+      enabled: process.env.FORWARD_25_ENABLED === 'true',
+      smtpHost: process.env.FORWARD_25_HOST || 'smtp.gmail.com',
+      smtpPort: parseInt(process.env.FORWARD_25_PORT) || 587,
+      username: process.env.FORWARD_25_USERNAME,
+      password: process.env.FORWARD_25_PASSWORD,
+      secure: process.env.FORWARD_25_SECURE === 'true',
+    },
   },
   database: {
     url: process.env.MONGODB_URL || 'mongodb://localhost:27017/smtp-server',

--- a/env.example
+++ b/env.example
@@ -3,6 +3,19 @@ SMTP_PORT=2525
 SMTP_HOST=0.0.0.0
 API_PORT=3000
 
+# Multi-Port SMTP Configuration
+SMTP_25_PORT=25
+SMTP_465_PORT=465
+SMTP_587_PORT=587
+
+# Port 25 Forwarding Configuration
+FORWARD_25_ENABLED=false
+FORWARD_25_HOST=smtp.gmail.com
+FORWARD_25_PORT=587
+FORWARD_25_USERNAME=your-email@gmail.com
+FORWARD_25_PASSWORD=your-app-password
+FORWARD_25_SECURE=true
+
 # Database Configuration
 MONGODB_URL=mongodb://localhost:27017/smtp-server
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "nodemon server.js",
     "test": "node test-send.js",
     "test:email": "node test-send.js",
-    "test:ip": "node test-ip-selection.js"
+    "test:ip": "node test-ip-selection.js",
+    "test:ports": "node test-multi-port.js"
   },
   "author": "Kunal Ghosh",
   "license": "ISC",

--- a/server.js
+++ b/server.js
@@ -1,13 +1,13 @@
 const config = require('./config/config');
 const database = require('./config/database');
-const SMTPServer = require('./services/SMTPServer');
+const MultiPortSMTPServer = require('./services/MultiPortSMTPServer');
 const QueueAPI = require('./services/QueueAPI');
 const DatabaseWatcher = require('./services/DatabaseWatcher');
 const logger = require('./utils/logger');
 
 class Application {
   constructor() {
-    this.smtpServer = null;
+    this.multiPortSMTPServer = null;
     this.queueAPI = null;
     this.isShuttingDown = false;
   }
@@ -21,9 +21,9 @@ class Application {
       DatabaseWatcher.startWatching();
       await DatabaseWatcher.processExistingPendingEmails();
       
-      // Start SMTP server
-      this.smtpServer = new SMTPServer(config.server.port, config.server.host);
-      this.smtpServer.start();
+      // Start Multi-Port SMTP server
+      this.multiPortSMTPServer = new MultiPortSMTPServer();
+      this.multiPortSMTPServer.start();
       
       // Start Queue API server
       this.queueAPI = new QueueAPI(config.server.apiPort || 3000);
@@ -47,9 +47,9 @@ class Application {
     logger.info('🛑 Shutting down application...');
     
     try {
-      // Stop SMTP server
-      if (this.smtpServer) {
-        this.smtpServer.stop();
+      // Stop Multi-Port SMTP server
+      if (this.multiPortSMTPServer) {
+        this.multiPortSMTPServer.stop();
       }
       
       // Stop Database Watcher

--- a/services/MultiPortSMTPServer.js
+++ b/services/MultiPortSMTPServer.js
@@ -1,0 +1,299 @@
+const net = require('net');
+const tls = require('tls');
+const fs = require('fs');
+const path = require('path');
+const EmailProcessor = require('./EmailProcessor');
+const SMTPForwarder = require('./SMTPForwarder');
+const logger = require('../utils/logger');
+
+class MultiPortSMTPServer {
+  constructor() {
+    this.servers = new Map();
+    this.forwarder = null;
+  }
+
+  start() {
+    const config = require('../config/config');
+    
+    // Initialize SMTP forwarder for port 25
+    if (config.server.forward25.enabled) {
+      this.forwarder = new SMTPForwarder(config.server.forward25);
+    }
+
+    // Start servers on different ports
+    this.startServer(config.server.ports.smtp25, 'forward', config.server.host);
+    this.startServer(config.server.ports.smtp587, 'starttls', config.server.host);
+    this.startServer(config.server.ports.smtp465, 'ssl', config.server.host);
+
+    logger.info('🚀 Multi-port SMTP servers started', {
+      port25: config.server.ports.smtp25,
+      port587: config.server.ports.smtp587,
+      port465: config.server.ports.smtp465,
+      forwarding: config.server.forward25.enabled
+    });
+  }
+
+  startServer(port, mode, host) {
+    let server;
+
+    if (mode === 'ssl') {
+      // SSL server for port 465
+      const sslOptions = this.getSSLOptions();
+      server = tls.createServer(sslOptions, (socket) => {
+        this.handleConnection(socket, mode, port);
+      });
+    } else {
+      // Regular TCP server for ports 25 and 587
+      server = net.createServer((socket) => {
+        this.handleConnection(socket, mode, port);
+      });
+    }
+
+    server.listen(port, host, () => {
+      logger.info(`📬 SMTP server listening on port ${port} (${mode.toUpperCase()})`);
+    });
+
+    server.on('error', (error) => {
+      logger.error(`🔥 Server error on port ${port}`, { error: error.message });
+    });
+
+    this.servers.set(port, { server, mode });
+  }
+
+  getSSLOptions() {
+    // Try to load SSL certificates
+    const certPath = process.env.SSL_CERT_PATH || './ssl/cert.pem';
+    const keyPath = process.env.SSL_KEY_PATH || './ssl/key.pem';
+
+    try {
+      if (fs.existsSync(certPath) && fs.existsSync(keyPath)) {
+        return {
+          cert: fs.readFileSync(certPath),
+          key: fs.readFileSync(keyPath)
+        };
+      } else {
+        logger.warn('SSL certificates not found, using self-signed certificate');
+        // Generate self-signed certificate for testing
+        return this.generateSelfSignedCert();
+      }
+    } catch (error) {
+      logger.warn('Failed to load SSL certificates, using self-signed certificate', { error: error.message });
+      return this.generateSelfSignedCert();
+    }
+  }
+
+  generateSelfSignedCert() {
+    // For development/testing purposes
+    const { execSync } = require('child_process');
+    const sslDir = './ssl';
+    
+    try {
+      if (!fs.existsSync(sslDir)) {
+        fs.mkdirSync(sslDir, { recursive: true });
+      }
+
+      const certPath = path.join(sslDir, 'cert.pem');
+      const keyPath = path.join(sslDir, 'key.pem');
+
+      if (!fs.existsSync(certPath) || !fs.existsSync(keyPath)) {
+        logger.info('Generating self-signed SSL certificate...');
+        
+        const opensslCmd = `openssl req -x509 -newkey rsa:2048 -keyout ${keyPath} -out ${certPath} -days 365 -nodes -subj "/C=US/ST=State/L=City/O=Organization/CN=localhost"`;
+        
+        try {
+          execSync(opensslCmd, { stdio: 'ignore' });
+          logger.info('Self-signed SSL certificate generated successfully');
+        } catch (error) {
+          logger.error('Failed to generate SSL certificate', { error: error.message });
+          // Fallback to basic SSL options
+          return {};
+        }
+      }
+
+      return {
+        cert: fs.readFileSync(certPath),
+        key: fs.readFileSync(keyPath)
+      };
+    } catch (error) {
+      logger.error('Error setting up SSL', { error: error.message });
+      return {};
+    }
+  }
+
+  handleConnection(socket, mode, port) {
+    logger.info(`📬 Client connected on port ${port} (${mode.toUpperCase()})`);
+
+    let sender = '';
+    let recipients = [];
+    let rawData = '';
+    let isDataMode = false;
+    let isAuthenticated = false;
+    let supportsStartTLS = false;
+    let startTLSUpgraded = false;
+
+    // Send welcome message
+    socket.write('220 Multi-Port SMTP Server Ready\r\n');
+
+    socket.on('data', async (chunk) => {
+      const lines = chunk.toString().split(/\r?\n/);
+
+      for (let line of lines) {
+        line = line.trim();
+
+        if (isDataMode) {
+          if (line === '.') {
+            isDataMode = false;
+            await this.handleEmailData(socket, sender, recipients, rawData, mode, port);
+            
+            // Reset state
+            rawData = '';
+            sender = '';
+            recipients = [];
+          } else {
+            rawData += line + '\r\n';
+          }
+          continue;
+        }
+
+        await this.handleSMTPCommand(socket, line, {
+          setSender: (s) => { sender = s; },
+          addRecipient: (r) => { recipients.push(r); },
+          setDataMode: (mode) => { isDataMode = mode; },
+          setAuthenticated: (auth) => { isAuthenticated = auth; },
+          setStartTLS: (tls) => { supportsStartTLS = tls; },
+          getStartTLS: () => supportsStartTLS,
+          isStartTLSUpgraded: () => startTLSUpgraded,
+          upgradeToTLS: () => { startTLSUpgraded = true; }
+        }, mode, port);
+      }
+    });
+
+    socket.on('end', () => {
+      logger.info(`❌ Client disconnected from port ${port}`);
+    });
+
+    socket.on('error', (err) => {
+      logger.error(`🔥 Socket error on port ${port}`, { error: err.message });
+    });
+  }
+
+  async handleSMTPCommand(socket, line, state, mode, port) {
+    if (line.startsWith('HELO') || line.startsWith('EHLO')) {
+      const domain = line.split(' ')[1] || 'localhost';
+      
+      if (line.startsWith('EHLO')) {
+        // Extended HELO - advertise capabilities
+        socket.write('250-Hello\r\n');
+        socket.write('250-SIZE 10485760\r\n');
+        
+        if (mode === 'starttls' && !state.isStartTLSUpgraded()) {
+          socket.write('250-STARTTLS\r\n');
+          state.setStartTLS(true);
+        }
+        
+        socket.write('250 AUTH PLAIN LOGIN\r\n');
+      } else {
+        socket.write('250 Hello\r\n');
+      }
+    } else if (line === 'STARTTLS' && mode === 'starttls' && !state.isStartTLSUpgraded()) {
+      socket.write('220 Ready to start TLS\r\n');
+      
+      // Upgrade the connection to TLS
+      const tlsOptions = this.getSSLOptions();
+      const tlsSocket = tls.connect({
+        socket: socket,
+        ...tlsOptions
+      });
+
+      tlsSocket.on('secure', () => {
+        logger.info('🔒 TLS connection established');
+        state.upgradeToTLS();
+        // Re-send welcome message after TLS upgrade
+        tlsSocket.write('220 Multi-Port SMTP Server Ready (TLS)\r\n');
+      });
+
+      tlsSocket.on('error', (error) => {
+        logger.error('TLS upgrade failed', { error: error.message });
+      });
+
+    } else if (line.startsWith('AUTH')) {
+      // Handle authentication (basic implementation)
+      if (line.includes('PLAIN') || line.includes('LOGIN')) {
+        socket.write('334 VXNlcm5hbWU6\r\n'); // Base64 for "Username:"
+        // For now, accept any authentication
+        isAuthenticated = true;
+        socket.write('235 Authentication successful\r\n');
+      } else {
+        socket.write('504 Authentication mechanism not supported\r\n');
+      }
+    } else if (line.startsWith('MAIL FROM:')) {
+      const sender = line.slice(10).replace(/[<>]/g, '').trim();
+      if (EmailProcessor.validateSender(sender)) {
+        state.setSender(sender);
+        socket.write('250 OK\r\n');
+      } else {
+        socket.write('501 Invalid sender\r\n');
+      }
+    } else if (line.startsWith('RCPT TO:')) {
+      const rcpt = line.slice(8).replace(/[<>]/g, '').trim();
+      if (EmailProcessor.validateRecipients([rcpt])) {
+        state.addRecipient(rcpt);
+        socket.write('250 OK\r\n');
+      } else {
+        socket.write('501 Invalid recipient\r\n');
+      }
+    } else if (line === 'DATA') {
+      state.setDataMode(true);
+      socket.write('354 End data with <CR><LF>.<CR><LF>\r\n');
+    } else if (line === 'QUIT') {
+      socket.write('221 Bye\r\n');
+      socket.end();
+    } else if (line === 'RSET') {
+      // Reset the current transaction
+      state.setSender('');
+      state.addRecipient = () => {}; // Clear recipients
+      state.setDataMode(false);
+      socket.write('250 OK\r\n');
+    } else {
+      socket.write('502 Command not implemented\r\n');
+    }
+  }
+
+  async handleEmailData(socket, sender, recipients, rawData, mode, port) {
+    try {
+      if (mode === 'forward' && this.forwarder) {
+        // Forward email to external SMTP service
+        await this.forwarder.forwardEmail(sender, recipients, rawData);
+        socket.write('250 Message forwarded successfully\r\n');
+      } else {
+        // Process email normally (add to queue)
+        await EmailProcessor.processEmail(sender, recipients, rawData);
+        socket.write('250 Message accepted\r\n');
+      }
+    } catch (error) {
+      logger.error(`❌ Failed to process email on port ${port}`, { error: error.message });
+      socket.write('550 Failed to process email\r\n');
+    }
+  }
+
+  stop() {
+    for (const [port, { server }] of this.servers) {
+      server.close();
+      logger.info(`🛑 SMTP server stopped on port ${port}`);
+    }
+    this.servers.clear();
+  }
+
+  getServerStats() {
+    const stats = {};
+    for (const [port, { mode }] of this.servers) {
+      stats[port] = {
+        mode,
+        status: 'running'
+      };
+    }
+    return stats;
+  }
+}
+
+module.exports = MultiPortSMTPServer; 

--- a/services/SMTPForwarder.js
+++ b/services/SMTPForwarder.js
@@ -1,0 +1,213 @@
+const net = require('net');
+const tls = require('tls');
+const logger = require('../utils/logger');
+
+class SMTPForwarder {
+  constructor(config) {
+    this.config = config;
+    this.timeout = 30000; // 30 seconds timeout
+  }
+
+  async forwardEmail(sender, recipients, rawEmail) {
+    try {
+      logger.info('📤 Forwarding email to external SMTP', {
+        sender,
+        recipients,
+        smtpHost: this.config.smtpHost,
+        smtpPort: this.config.smtpPort
+      });
+
+      const result = await this.sendToExternalSMTP(sender, recipients, rawEmail);
+      
+      logger.info('✅ Email forwarded successfully', {
+        sender,
+        recipients,
+        smtpHost: this.config.smtpHost
+      });
+
+      return result;
+    } catch (error) {
+      logger.error('❌ Failed to forward email', {
+        error: error.message,
+        sender,
+        recipients,
+        smtpHost: this.config.smtpHost
+      });
+      throw error;
+    }
+  }
+
+  async sendToExternalSMTP(sender, recipients, rawEmail) {
+    return new Promise((resolve, reject) => {
+      let socket;
+      
+      if (this.config.secure) {
+        // Use TLS connection
+        socket = tls.connect({
+          host: this.config.smtpHost,
+          port: this.config.smtpPort,
+          timeout: this.timeout,
+          rejectUnauthorized: false // Allow self-signed certificates
+        });
+      } else {
+        // Use regular TCP connection
+        socket = new net.Socket();
+        socket.setTimeout(this.timeout);
+        socket.connect(this.config.smtpPort, this.config.smtpHost);
+      }
+
+      let response = '';
+      let isDataMode = false;
+      let dataSent = false;
+      let isAuthenticated = false;
+
+      socket.on('connect', () => {
+        logger.debug(`Connected to external SMTP: ${this.config.smtpHost}:${this.config.smtpPort}`);
+      });
+
+      socket.on('secureConnect', () => {
+        logger.debug('TLS connection established with external SMTP');
+      });
+
+      socket.on('data', (chunk) => {
+        const lines = chunk.toString().split(/\r?\n/);
+        
+        for (const line of lines) {
+          const trimmedLine = line.trim();
+          if (!trimmedLine) continue;
+
+          response += trimmedLine + '\n';
+          
+          // Check for error responses
+          if (trimmedLine.startsWith('4') || trimmedLine.startsWith('5')) {
+            socket.end();
+            reject(new Error(`SMTP Error: ${trimmedLine}`));
+            return;
+          }
+
+          // Handle different SMTP responses
+          if (trimmedLine.startsWith('220')) {
+            // Server ready, send EHLO
+            socket.write(`EHLO ${this.config.smtpHost}\r\n`);
+          } else if (trimmedLine.startsWith('250') && !isDataMode && !isAuthenticated) {
+            // EHLO successful, start authentication if credentials provided
+            if (this.config.username && this.config.password) {
+              this.startAuthentication(socket);
+            } else {
+              // No authentication, send MAIL FROM
+              socket.write(`MAIL FROM:<${sender}>\r\n`);
+            }
+          } else if (trimmedLine.startsWith('334')) {
+            // Auth challenge
+            this.handleAuthChallenge(socket, trimmedLine);
+          } else if (trimmedLine.startsWith('235')) {
+            // Auth successful
+            isAuthenticated = true;
+            socket.write(`MAIL FROM:<${sender}>\r\n`);
+          } else if (trimmedLine.startsWith('250') && isAuthenticated && !dataSent) {
+            // MAIL FROM successful, send RCPT TO
+            socket.write(`RCPT TO:<${recipients[0]}>\r\n`);
+          } else if (trimmedLine.startsWith('250') && dataSent) {
+            // Email sent successfully
+            socket.write('QUIT\r\n');
+            socket.end();
+            resolve(response);
+          } else if (trimmedLine.startsWith('354')) {
+            // Ready for data
+            isDataMode = true;
+            socket.write(rawEmail + '\r\n.\r\n');
+            dataSent = true;
+          } else if (trimmedLine.startsWith('221')) {
+            // Server closing connection
+            socket.end();
+            resolve(response);
+          }
+        }
+      });
+
+      socket.on('timeout', () => {
+        socket.destroy();
+        reject(new Error('Connection timeout'));
+      });
+
+      socket.on('error', (error) => {
+        reject(new Error(`Connection error: ${error.message}`));
+      });
+
+      socket.on('close', () => {
+        if (!dataSent) {
+          reject(new Error('Connection closed before email could be sent'));
+        }
+      });
+    });
+  }
+
+  startAuthentication(socket) {
+    // Start PLAIN authentication
+    const authString = Buffer.from(`\0${this.config.username}\0${this.config.password}`).toString('base64');
+    socket.write(`AUTH PLAIN ${authString}\r\n`);
+  }
+
+  handleAuthChallenge(socket, challenge) {
+    // Handle different authentication challenges
+    if (challenge.includes('VXNlcm5hbWU6')) {
+      // Username challenge (Base64 for "Username:")
+      const username = Buffer.from(this.config.username).toString('base64');
+      socket.write(username + '\r\n');
+    } else if (challenge.includes('UGFzc3dvcmQ6')) {
+      // Password challenge (Base64 for "Password:")
+      const password = Buffer.from(this.config.password).toString('base64');
+      socket.write(password + '\r\n');
+    } else {
+      // Unknown challenge, try to decode and handle
+      try {
+        const decoded = Buffer.from(challenge, 'base64').toString();
+        if (decoded.toLowerCase().includes('username')) {
+          const username = Buffer.from(this.config.username).toString('base64');
+          socket.write(username + '\r\n');
+        } else if (decoded.toLowerCase().includes('password')) {
+          const password = Buffer.from(this.config.password).toString('base64');
+          socket.write(password + '\r\n');
+        } else {
+          socket.write('\r\n'); // Send empty response
+        }
+      } catch (error) {
+        socket.write('\r\n'); // Send empty response
+      }
+    }
+  }
+
+  // Test connection to external SMTP
+  async testConnection() {
+    try {
+      const testEmail = {
+        sender: 'test@example.com',
+        recipients: ['test@example.com'],
+        raw: 'From: test@example.com\r\nTo: test@example.com\r\nSubject: Test\r\n\r\nTest message\r\n'
+      };
+
+      await this.forwardEmail(
+        testEmail.sender,
+        testEmail.recipients,
+        testEmail.raw
+      );
+
+      return { success: true, message: 'Connection test successful' };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  }
+
+  // Get forwarder configuration (without sensitive data)
+  getConfig() {
+    return {
+      enabled: true,
+      smtpHost: this.config.smtpHost,
+      smtpPort: this.config.smtpPort,
+      secure: this.config.secure,
+      hasCredentials: !!(this.config.username && this.config.password)
+    };
+  }
+}
+
+module.exports = SMTPForwarder; 

--- a/test-multi-port.js
+++ b/test-multi-port.js
@@ -1,0 +1,314 @@
+const net = require('net');
+const tls = require('tls');
+const fs = require('fs');
+
+// Test configuration
+const testConfig = {
+  port25: 25,    // Forwarding port
+  port587: 587,  // STARTTLS port
+  port465: 465   // SSL port
+};
+
+// Test email data
+const testEmail = {
+  sender: 'test@example.com',
+  recipient: 'recipient@example.com',
+  subject: 'Multi-Port SMTP Test',
+  body: `From: test@example.com
+To: recipient@example.com
+Subject: Multi-Port SMTP Test
+Date: ${new Date().toISOString()}
+Content-Type: text/plain; charset=UTF-8
+
+This is a test email sent through multi-port SMTP server.
+
+Ports tested:
+- Port 25: Forwarding to external SMTP
+- Port 587: STARTTLS encryption
+- Port 465: SSL encryption
+
+Best regards,
+Test System`
+};
+
+// Test functions for different ports
+async function testPort25() {
+  console.log('\n🔌 Testing Port 25 (Forwarding)...');
+  console.log('─'.repeat(50));
+  
+  return new Promise((resolve, reject) => {
+    const socket = new net.Socket();
+    let response = '';
+
+    socket.on('connect', () => {
+      console.log('📧 Connected to port 25');
+    });
+
+    socket.on('data', (chunk) => {
+      const lines = chunk.toString().split(/\r?\n/);
+      
+      for (const line of lines) {
+        const trimmedLine = line.trim();
+        if (!trimmedLine) continue;
+
+        response += trimmedLine + '\n';
+        console.log(`📨 Server: ${trimmedLine}`);
+
+        // Handle SMTP responses
+        if (trimmedLine.startsWith('220')) {
+          console.log('📤 Sending: EHLO example.com');
+          socket.write('EHLO example.com\r\n');
+        } else if (trimmedLine.startsWith('250') && !response.includes('MAIL FROM')) {
+          console.log(`📤 Sending: MAIL FROM:<${testEmail.sender}>`);
+          socket.write(`MAIL FROM:<${testEmail.sender}>\r\n`);
+        } else if (trimmedLine.startsWith('250') && response.includes('MAIL FROM') && !response.includes('RCPT TO')) {
+          console.log(`📤 Sending: RCPT TO:<${testEmail.recipient}>`);
+          socket.write(`RCPT TO:<${testEmail.recipient}>\r\n`);
+        } else if (trimmedLine.startsWith('250') && response.includes('RCPT TO') && !response.includes('DATA')) {
+          console.log('📤 Sending: DATA');
+          socket.write('DATA\r\n');
+        } else if (trimmedLine.startsWith('354')) {
+          console.log('📤 Sending email content...');
+          socket.write(testEmail.body + '\r\n.\r\n');
+        } else if (trimmedLine.startsWith('250') && response.includes('DATA')) {
+          console.log('📤 Sending: QUIT');
+          socket.write('QUIT\r\n');
+        } else if (trimmedLine.startsWith('221')) {
+          console.log('✅ Email forwarded successfully via port 25!');
+          socket.end();
+          resolve(response);
+        } else if (trimmedLine.startsWith('4') || trimmedLine.startsWith('5')) {
+          console.error(`❌ SMTP Error: ${trimmedLine}`);
+          socket.end();
+          reject(new Error(`SMTP Error: ${trimmedLine}`));
+        }
+      }
+    });
+
+    socket.on('error', (error) => {
+      console.error('❌ Connection error:', error.message);
+      reject(error);
+    });
+
+    socket.on('close', () => {
+      console.log('🔌 Connection closed');
+    });
+
+    console.log('🔌 Connecting to port 25...');
+    socket.connect(testConfig.port25, 'localhost');
+  });
+}
+
+async function testPort587() {
+  console.log('\n🔌 Testing Port 587 (STARTTLS)...');
+  console.log('─'.repeat(50));
+  
+  return new Promise((resolve, reject) => {
+    const socket = new net.Socket();
+    let response = '';
+    let tlsUpgraded = false;
+
+    socket.on('connect', () => {
+      console.log('📧 Connected to port 587');
+    });
+
+    socket.on('data', (chunk) => {
+      const lines = chunk.toString().split(/\r?\n/);
+      
+      for (const line of lines) {
+        const trimmedLine = line.trim();
+        if (!trimmedLine) continue;
+
+        response += trimmedLine + '\n';
+        console.log(`📨 Server: ${trimmedLine}`);
+
+        // Handle SMTP responses
+        if (trimmedLine.startsWith('220')) {
+          console.log('📤 Sending: EHLO example.com');
+          socket.write('EHLO example.com\r\n');
+        } else if (trimmedLine.startsWith('250') && !tlsUpgraded) {
+          console.log('📤 Sending: STARTTLS');
+          socket.write('STARTTLS\r\n');
+        } else if (trimmedLine.startsWith('220') && !tlsUpgraded) {
+          console.log('🔒 Starting TLS upgrade...');
+          tlsUpgraded = true;
+          
+          // Upgrade to TLS
+          const tlsSocket = tls.connect({
+            socket: socket,
+            rejectUnauthorized: false
+          });
+
+          tlsSocket.on('secure', () => {
+            console.log('🔒 TLS connection established');
+            tlsSocket.write('EHLO example.com\r\n');
+          });
+
+          tlsSocket.on('data', (tlsChunk) => {
+            const tlsLines = tlsChunk.toString().split(/\r?\n/);
+            
+            for (const tlsLine of tlsLines) {
+              const trimmedTlsLine = tlsLine.trim();
+              if (!trimmedTlsLine) continue;
+
+              console.log(`📨 Server (TLS): ${trimmedTlsLine}`);
+
+              if (trimmedTlsLine.startsWith('250')) {
+                console.log(`📤 Sending: MAIL FROM:<${testEmail.sender}>`);
+                tlsSocket.write(`MAIL FROM:<${testEmail.sender}>\r\n`);
+              } else if (trimmedTlsLine.startsWith('250') && response.includes('MAIL FROM') && !response.includes('RCPT TO')) {
+                console.log(`📤 Sending: RCPT TO:<${testEmail.recipient}>`);
+                tlsSocket.write(`RCPT TO:<${testEmail.recipient}>\r\n`);
+              } else if (trimmedTlsLine.startsWith('250') && response.includes('RCPT TO') && !response.includes('DATA')) {
+                console.log('📤 Sending: DATA');
+                tlsSocket.write('DATA\r\n');
+              } else if (trimmedTlsLine.startsWith('354')) {
+                console.log('📤 Sending email content...');
+                tlsSocket.write(testEmail.body + '\r\n.\r\n');
+              } else if (trimmedTlsLine.startsWith('250') && response.includes('DATA')) {
+                console.log('📤 Sending: QUIT');
+                tlsSocket.write('QUIT\r\n');
+              } else if (trimmedTlsLine.startsWith('221')) {
+                console.log('✅ Email sent successfully via port 587 (STARTTLS)!');
+                tlsSocket.end();
+                resolve(response);
+              }
+            }
+          });
+        }
+      }
+    });
+
+    socket.on('error', (error) => {
+      console.error('❌ Connection error:', error.message);
+      reject(error);
+    });
+
+    console.log('🔌 Connecting to port 587...');
+    socket.connect(testConfig.port587, 'localhost');
+  });
+}
+
+async function testPort465() {
+  console.log('\n🔌 Testing Port 465 (SSL)...');
+  console.log('─'.repeat(50));
+  
+  return new Promise((resolve, reject) => {
+    const tlsSocket = tls.connect({
+      host: 'localhost',
+      port: testConfig.port465,
+      rejectUnauthorized: false
+    });
+
+    let response = '';
+
+    tlsSocket.on('secureConnect', () => {
+      console.log('🔒 SSL connection established');
+    });
+
+    tlsSocket.on('data', (chunk) => {
+      const lines = chunk.toString().split(/\r?\n/);
+      
+      for (const line of lines) {
+        const trimmedLine = line.trim();
+        if (!trimmedLine) continue;
+
+        response += trimmedLine + '\n';
+        console.log(`📨 Server: ${trimmedLine}`);
+
+        // Handle SMTP responses
+        if (trimmedLine.startsWith('220')) {
+          console.log('📤 Sending: EHLO example.com');
+          tlsSocket.write('EHLO example.com\r\n');
+        } else if (trimmedLine.startsWith('250') && !response.includes('MAIL FROM')) {
+          console.log(`📤 Sending: MAIL FROM:<${testEmail.sender}>`);
+          tlsSocket.write(`MAIL FROM:<${testEmail.sender}>\r\n`);
+        } else if (trimmedLine.startsWith('250') && response.includes('MAIL FROM') && !response.includes('RCPT TO')) {
+          console.log(`📤 Sending: RCPT TO:<${testEmail.recipient}>`);
+          tlsSocket.write(`RCPT TO:<${testEmail.recipient}>\r\n`);
+        } else if (trimmedLine.startsWith('250') && response.includes('RCPT TO') && !response.includes('DATA')) {
+          console.log('📤 Sending: DATA');
+          tlsSocket.write('DATA\r\n');
+        } else if (trimmedLine.startsWith('354')) {
+          console.log('📤 Sending email content...');
+          tlsSocket.write(testEmail.body + '\r\n.\r\n');
+        } else if (trimmedLine.startsWith('250') && response.includes('DATA')) {
+          console.log('📤 Sending: QUIT');
+          tlsSocket.write('QUIT\r\n');
+        } else if (trimmedLine.startsWith('221')) {
+          console.log('✅ Email sent successfully via port 465 (SSL)!');
+          tlsSocket.end();
+          resolve(response);
+        } else if (trimmedLine.startsWith('4') || trimmedLine.startsWith('5')) {
+          console.error(`❌ SMTP Error: ${trimmedLine}`);
+          tlsSocket.end();
+          reject(new Error(`SMTP Error: ${trimmedLine}`));
+        }
+      }
+    });
+
+    tlsSocket.on('error', (error) => {
+      console.error('❌ SSL connection error:', error.message);
+      reject(error);
+    });
+
+    tlsSocket.on('close', () => {
+      console.log('🔌 SSL connection closed');
+    });
+
+    console.log('🔌 Connecting to port 465 (SSL)...');
+  });
+}
+
+// Run all tests
+async function runAllTests() {
+  try {
+    console.log('🧪 Starting Multi-Port SMTP Tests...\n');
+    
+    // Test port 25 (forwarding)
+    try {
+      await testPort25();
+    } catch (error) {
+      console.error('❌ Port 25 test failed:', error.message);
+    }
+
+    // Wait between tests
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    // Test port 587 (STARTTLS)
+    try {
+      await testPort587();
+    } catch (error) {
+      console.error('❌ Port 587 test failed:', error.message);
+    }
+
+    // Wait between tests
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    // Test port 465 (SSL)
+    try {
+      await testPort465();
+    } catch (error) {
+      console.error('❌ Port 465 test failed:', error.message);
+    }
+
+    console.log('\n🎉 Multi-port SMTP tests completed!');
+    console.log('\n📊 Check the queue dashboard at: http://localhost:3000');
+    
+  } catch (error) {
+    console.error('\n💥 Test failed:', error.message);
+  }
+}
+
+// Check if server is running
+const checkServer = new net.Socket();
+checkServer.on('error', () => {
+  console.error('❌ SMTP server is not running');
+  console.log('💡 Please start the server first: npm start');
+  process.exit(1);
+});
+
+checkServer.connect(25, 'localhost', () => {
+  checkServer.destroy();
+  runAllTests();
+}); 


### PR DESCRIPTION
- Introduced support for multiple SMTP ports (25, 465, 587) in the configuration.
- Updated the application to use a MultiPortSMTPServer instead of a single SMTPServer.
- Added endpoints for retrieving SMTP server statistics.
- Enhanced README with multi-port SMTP details and testing instructions.
- Updated package.json to include a new test script for multi-port functionality.